### PR TITLE
[Feat] 회원 정보 수정, 로그아웃 구현

### DIFF
--- a/app/(pola)/user/profile/[nickname]/_styles/userProfile.module.css
+++ b/app/(pola)/user/profile/[nickname]/_styles/userProfile.module.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   align-items: center;
   gap: 4rem;
-  padding: 3rem 1.5rem;
-  width: calc(100% - 3rem);
+  width: 100%;
+  margin-bottom: 10rem;
   font-family: var(--font-pretendard);
 }
 

--- a/app/(pola)/user/profile/[nickname]/page.tsx
+++ b/app/(pola)/user/profile/[nickname]/page.tsx
@@ -18,7 +18,6 @@ import { useAuthStore } from "@/lib/stores/authStore";
 const UserProfilePage: React.FC = () => {
   const params = useParams();
   const nickname = params.nickname as string;
-  const url = ``
 
   // 현재 로그인한 유저 정보 가져오기
   const currentUser = useAuthStore((state) => state.user);

--- a/app/(pola)/user/profile/[nickname]/settings/page.module.css
+++ b/app/(pola)/user/profile/[nickname]/settings/page.module.css
@@ -1,0 +1,395 @@
+.container {
+  width: 100%;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #ffffff 0%, #f0f8ff 100%);
+  padding: 0 1.5rem;
+  padding-bottom: 2rem;
+}
+
+/* Profile Image Section */
+.profileImageSection {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+
+.profileImageContainer {
+  position: relative;
+  display: inline-block;
+}
+
+.profileImage {
+  width: 7.5rem;
+  height: 7.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 0.25rem solid #fff;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.1);
+}
+
+.cameraButton {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0.125rem 0.5rem rgba(59, 130, 246, 0.3);
+  transition: transform 0.2s;
+}
+
+.cameraButton:hover {
+  transform: scale(1.05);
+}
+
+/* Form Container */
+.formContainer {
+  width: 100%;
+  margin: 0 auto;
+}
+
+.formField {
+  margin-bottom: 2rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #666;
+  margin-bottom: 0.75rem;
+}
+
+.input {
+  width: 100%;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  border: 0.125rem solid transparent;
+  border-radius: 1rem;
+  font-size: 1rem;
+  color: #333;
+  transition: all 0.2s;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  background: linear-gradient(135deg, #f8faff 0%, #eff6ff 100%);
+  box-shadow: 0 0 0 0.25rem rgba(59, 130, 246, 0.1);
+}
+
+.input:disabled {
+  background: #f1f5f9;
+  color: #64748b;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.inputWithIcon {
+  position: relative;
+}
+
+.dropdownIcon {
+  position: absolute;
+  right: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #3b82f6;
+  pointer-events: none;
+}
+
+/* Gender Selection */
+.genderContainer {
+  display: flex;
+  gap: 1rem;
+}
+
+.genderButton {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  border: 0.125rem solid transparent;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 1rem;
+  color: #333;
+}
+
+.genderButton:hover {
+  background: linear-gradient(135deg, #f8faff 0%, #eff6ff 100%);
+}
+
+.genderButton.selected {
+  border-color: #3b82f6;
+  background: linear-gradient(135deg, #f8faff 0%, #eff6ff 100%);
+  box-shadow: 0 0 0 0.25rem rgba(59, 130, 246, 0.1);
+}
+
+.radioButton {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 0.125rem solid #ddd;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.radioSelected {
+  border-color: #3b82f6;
+  background: #3b82f6;
+  position: relative;
+}
+
+.radioSelected::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 0.5rem;
+  height: 0.5rem;
+  background: white;
+  border-radius: 50%;
+}
+
+/* Password Button */
+.passwordButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  border: 0.125rem solid transparent;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 1rem;
+  color: #333;
+  text-align: left;
+}
+
+.passwordButton:hover {
+  background: linear-gradient(135deg, #f8faff 0%, #eff6ff 100%);
+  border-color: #3b82f6;
+}
+
+/* Save Button */
+.saveButton {
+  width: 100%;
+  padding: 1.25rem;
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  border: none;
+  border-radius: 1rem;
+  color: white;
+  font-size: 1.125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-top: 1rem;
+  box-shadow: 0 0.25rem 1rem rgba(59, 130, 246, 0.3);
+}
+
+.saveButton:hover {
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.5rem 1.5rem rgba(59, 130, 246, 0.4);
+}
+
+.saveButton:active {
+  transform: translateY(0);
+}
+
+/* Modal */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal {
+  background: white;
+  border-radius: 1.5rem;
+  width: 100%;
+  max-width: 28rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.2);
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 1.5rem 0 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.modalHeader h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s;
+}
+
+.closeButton:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.modalContent {
+  padding: 0 1.5rem;
+}
+
+.modalFooter {
+  display: flex;
+  gap: 1rem;
+  padding: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.cancelButton {
+  flex: 1;
+  padding: 1rem;
+  background: #eff6ff;
+  border: 0.125rem solid #dbeafe;
+  border-radius: 1rem;
+  color: #666;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cancelButton:hover {
+  background: #dbeafe;
+  border-color: #bfdbfe;
+}
+
+.confirmButton {
+  flex: 1;
+  padding: 1rem;
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  border: none;
+  border-radius: 1rem;
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 0.25rem 1rem rgba(59, 130, 246, 0.3);
+}
+
+.confirmButton:hover {
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.5rem 1.5rem rgba(59, 130, 246, 0.4);
+}
+
+/* Loading Styles */
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  gap: 1rem;
+}
+
+.loadingSpinner {
+  width: 3rem;
+  height: 3rem;
+  border: 0.25rem solid #f3f4f6;
+  border-top: 0.25rem solid #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loadingContainer p {
+  color: #666;
+  font-size: 1rem;
+}
+
+/* Responsive Design */
+@media (max-width: 48rem) {
+  .container {
+    padding: 0 1rem;
+  }
+
+  .profileImage {
+    width: 6rem;
+    height: 6rem;
+  }
+
+  .cameraButton {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .formContainer {
+    max-width: 100%;
+  }
+
+  .genderContainer {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .modal {
+    margin: 1rem;
+    max-width: calc(100% - 2rem);
+  }
+}
+
+@media (max-width: 36rem) {
+  .container {
+    padding: 0 0.75rem;
+  }
+
+  .input,
+  .genderButton,
+  .passwordButton {
+    padding: 0.875rem 1rem;
+    font-size: 0.875rem;
+  }
+
+  .saveButton {
+    padding: 1rem;
+    font-size: 1rem;
+  }
+}

--- a/app/(pola)/user/profile/[nickname]/settings/page.tsx
+++ b/app/(pola)/user/profile/[nickname]/settings/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useParams } from "next/navigation";
+import Image from "next/image";
+import { useForm, SubmitHandler } from "react-hook-form";
+import DaumPostcode, { Address } from "react-daum-postcode";
+import styles from "./page.module.css";
+import { UserProfileResponseDto } from "@/backend/common/dtos/UserDto";
+import { useApiQuery } from "@/lib/hooks/useApi";
+
+export default function UserSettingsPage() {
+  const params = useParams();
+  const nickname = params.nickname as string;
+
+  // API에서 사용자 프로필 데이터 가져오기
+  const { data: userProfile, isLoading } = useApiQuery<UserProfileResponseDto>(
+    ["userProfile", nickname],
+    `/api/users/${nickname}`,
+    {
+      enabled: !!nickname,
+    }
+  );
+
+  // 닉네임을 제외하고 프로필 이미지를 파일로 처리하는 타입 정의
+  type EditableUserData = Omit<
+    UserProfileResponseDto,
+    "nickname" | "profileImgUrl"
+  > & {
+    profileImage?: File;
+  };
+
+  const { register, handleSubmit, setValue } = useForm<EditableUserData>({
+    defaultValues: {
+      name: "",
+      age: 0,
+      address: "",
+    },
+  });
+
+  // API 데이터가 로드되면 폼 데이터 업데이트
+  useEffect(() => {
+    if (userProfile?.data) {
+      // 닉네임을 제외한 필드들만 폼에 설정
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { nickname, ...editableData } = userProfile.data;
+      Object.entries(editableData).forEach(([key, value]) => {
+        setValue(key as keyof EditableUserData, value);
+      });
+      // 주소 값도 설정
+      if (userProfile.data.address) {
+        setAddressValue(userProfile.data.address);
+      }
+    }
+  }, [userProfile, setValue]);
+
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [passwordData, setPasswordData] = useState({
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  // DaumPostcode 관련 상태
+  const [isAddressOpen, setIsAddressOpen] = useState(false);
+  const [addressValue, setAddressValue] = useState("");
+  const daumPostcodeRef = useRef<HTMLDivElement>(null);
+
+  // 프로필 이미지 관련 상태
+  const [previewUrl, setPreviewUrl] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handlePasswordChange = (field: string, value: string) => {
+    setPasswordData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const onSubmit: SubmitHandler<EditableUserData> = (data) => {
+    // TODO: API 호출하여 프로필 정보 저장
+    console.log("프로필 정보 저장:", data);
+
+    // FormData를 사용하여 파일과 함께 전송
+    const formData = new FormData();
+    formData.append("name", data.name);
+    formData.append("age", data.age.toString());
+    formData.append("address", data.address);
+
+    if (data.profileImage) {
+      formData.append("profileImage", data.profileImage);
+    }
+
+    console.log("FormData:", formData);
+  };
+
+  const handleChangePassword = () => {
+    // TODO: API 호출하여 비밀번호 변경
+    console.log("비밀번호 변경:", passwordData);
+    setShowPasswordModal(false);
+    setPasswordData({
+      currentPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    });
+  };
+
+  const handleProfileImageChange = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      // 파일 유효성 검사
+      if (!file.type.startsWith("image/")) {
+        alert("이미지 파일만 선택할 수 있습니다.");
+        return;
+      }
+
+      if (file.size > 5 * 1024 * 1024) {
+        // 5MB 제한
+        alert("파일 크기는 5MB 이하여야 합니다.");
+        return;
+      }
+
+      // 미리보기 URL 생성
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+
+      // react-hook-form에 파일 설정
+      setValue("profileImage", file);
+    }
+  };
+
+  // DaumPostcode 관련 함수들
+  const handleAddressClick = () => {
+    setIsAddressOpen(true);
+  };
+
+  const handleComplete = (data: Address) => {
+    setAddressValue(data.address);
+    setValue("address", data.address); // react-hook-form 값도 동기화
+    setIsAddressOpen(false);
+  };
+
+  useEffect(() => {
+    if (isAddressOpen && daumPostcodeRef.current) {
+      daumPostcodeRef.current.focus();
+    }
+  }, [isAddressOpen]);
+
+  // 로딩 중일 때 표시할 내용
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loadingContainer}>
+          <div className={styles.loadingSpinner}></div>
+          <p>사용자 데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      {/* Profile Image Section */}
+      <div className={styles.profileImageSection}>
+        <div className={styles.profileImageContainer}>
+          <Image
+            src={
+              previewUrl ||
+              userProfile?.data?.profileImgUrl ||
+              "/images/dummies/dummy_user.png"
+            }
+            alt="Profile"
+            width={120}
+            height={120}
+            className={styles.profileImage}
+          />
+          <button
+            className={styles.cameraButton}
+            onClick={handleProfileImageChange}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M23 19C23 19.5304 22.7893 20.0391 22.4142 20.4142C22.0391 20.7893 21.5304 21 21 21H3C2.46957 21 1.96086 20.7893 1.58579 20.4142C1.21071 20.0391 1 19.5304 1 19V8C1 7.46957 1.21071 6.96086 1.58579 6.58579C1.96086 6.21071 2.46957 6 3 6H7L9 3H15L17 6H21C21.5304 6 22.0391 6.21071 22.4142 6.58579C22.7893 6.96086 23 7.46957 23 8V19Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M12 17C14.2091 17 16 15.2091 16 13C16 10.7909 14.2091 9 12 9C9.79086 9 8 10.7909 8 13C8 15.2091 9.79086 17 12 17Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Hidden file input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleImageSelect}
+          style={{ display: "none" }}
+        />
+      </div>
+
+      {/* Form Fields */}
+      <form className={styles.formContainer} onSubmit={handleSubmit(onSubmit)}>
+        <div className={styles.formField}>
+          <label className={styles.label}>이름</label>
+          <input type="text" className={styles.input} {...register("name")} />
+        </div>
+
+        <div className={styles.formField}>
+          <label className={styles.label}>나이</label>
+          <input
+            type="number"
+            className={styles.input}
+            {...register("age", { valueAsNumber: true })}
+          />
+        </div>
+
+        <div className={styles.formField}>
+          <label className={styles.label}>주소</label>
+          <input
+            type="text"
+            className={styles.input}
+            value={addressValue}
+            readOnly
+            onClick={handleAddressClick}
+            {...register("address")}
+          />
+        </div>
+
+        <div className={styles.formField}>
+          <label className={styles.label}>닉네임</label>
+          <input
+            type="text"
+            className={styles.input}
+            value={userProfile?.data?.nickname || ""}
+            readOnly
+            disabled
+          />
+        </div>
+
+        {/* Password Change Button */}
+        <div className={styles.formField}>
+          <button
+            type="button"
+            className={styles.passwordButton}
+            onClick={() => setShowPasswordModal(true)}
+          >
+            <span>비밀번호 변경</span>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M9 12L15 12"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M12 9L12 15"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Save Button */}
+        <button type="submit" className={styles.saveButton}>
+          변경사항 저장
+        </button>
+      </form>
+
+      {/* Password Change Modal */}
+      {showPasswordModal && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <div className={styles.modalHeader}>
+              <h2>비밀번호 변경</h2>
+              <button
+                className={styles.closeButton}
+                onClick={() => setShowPasswordModal(false)}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M18 6L6 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M6 6L18 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <div className={styles.modalContent}>
+              <div className={styles.formField}>
+                <label className={styles.label}>현재 비밀번호</label>
+                <input
+                  type="password"
+                  value={passwordData.currentPassword}
+                  onChange={(e) =>
+                    handlePasswordChange("currentPassword", e.target.value)
+                  }
+                  className={styles.input}
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label className={styles.label}>새 비밀번호</label>
+                <input
+                  type="password"
+                  value={passwordData.newPassword}
+                  onChange={(e) =>
+                    handlePasswordChange("newPassword", e.target.value)
+                  }
+                  className={styles.input}
+                />
+              </div>
+
+              <div className={styles.formField}>
+                <label className={styles.label}>새 비밀번호 확인</label>
+                <input
+                  type="password"
+                  value={passwordData.confirmPassword}
+                  onChange={(e) =>
+                    handlePasswordChange("confirmPassword", e.target.value)
+                  }
+                  className={styles.input}
+                />
+              </div>
+            </div>
+
+            <div className={styles.modalFooter}>
+              <button
+                className={styles.cancelButton}
+                onClick={() => setShowPasswordModal(false)}
+              >
+                취소
+              </button>
+              <button
+                className={styles.confirmButton}
+                onClick={handleChangePassword}
+              >
+                비밀번호 변경
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* DaumPostcode Modal */}
+      {isAddressOpen && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal} ref={daumPostcodeRef} tabIndex={-1}>
+            <div className={styles.modalHeader}>
+              <h2>주소 검색</h2>
+              <button
+                className={styles.closeButton}
+                onClick={() => setIsAddressOpen(false)}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M18 6L6 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M6 6L18 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className={styles.modalContent}>
+              <DaumPostcode onComplete={handleComplete} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_components/LayoutWrapper.tsx
+++ b/app/_components/LayoutWrapper.tsx
@@ -1,21 +1,17 @@
-'use client';
-import { usePathname } from 'next/navigation';
-import Header from './Header';
-import Footer from './Footer';
+"use client";
+import { usePathname } from "next/navigation";
+import Header from "./Header";
+import Footer from "./Footer";
 
 // Header를 숨길 페이지들
-const hideHeaderPaths = [
-  '/login',
-  '/sign-up',
-  '/find-password',
-];
+const hideHeaderPaths = ["/login", "/sign-up", "/find-password"];
 
 // Footer를 숨길 페이지들
 const hideFooterPaths = [
-  '/login',
-  '/sign-up',
-  '/user/hall-of-fame',
-  '/find-password',
+  "/login",
+  "/sign-up",
+  "/user/hall-of-fame",
+  "/find-password",
 ];
 
 interface LayoutWrapperProps {
@@ -24,15 +20,15 @@ interface LayoutWrapperProps {
 
 export default function LayoutWrapper({ children }: LayoutWrapperProps) {
   const pathname = usePathname();
-  
+
   const shouldShowHeader = !hideHeaderPaths.includes(pathname);
   const shouldShowFooter = !hideFooterPaths.includes(pathname);
 
   return (
     <>
       {shouldShowHeader && <Header />}
-      <main className='main-container'>{children}</main>
+      <main className="main-container">{children}</main>
       {shouldShowFooter && <Footer />}
     </>
   );
-} 
+}

--- a/app/api/images/profile/route.ts
+++ b/app/api/images/profile/route.ts
@@ -92,6 +92,7 @@ export async function POST(
 
     // 3. 사용자 테이블에 프로필 이미지 URL 업데이트
     if (user) {
+      console.log(`[API] 업데이트할 프로필 이미지 URL: ${result.url}`);
       const userUseCase = new CommonUserUseCase(userRepository);
       const updatedUser = await userUseCase.updateUserProfile(user.id, {
         profile_img_url: result.url,

--- a/app/api/users/[nickname]/password-change/route.ts
+++ b/app/api/users/[nickname]/password-change/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUuidByNickname } from '@/lib/getUserData';
+import { PasswordChangeUseCase } from '@/backend/users/profile-update/applications/usecases/ProfileUpdateUseCase';
+import { SbProfileUpdateRepository } from '@/backend/users/profile-update/infrastructures/repositories/SbProfileUpdateRepository';
+
+// 의존성 주입을 위한 UseCase 인스턴스 생성
+const createPasswordChangeUseCase = () => {
+  const repository = new SbProfileUpdateRepository();
+  return new PasswordChangeUseCase(repository);
+};
+
+// 비밀번호 변경 API
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ nickname: string }> }
+) {
+  try {
+    const { nickname } = await params;
+
+    if (!nickname || nickname.trim() === '') {
+      return NextResponse.json({ error: 'nickname이 필요합니다.' }, { status: 400 });
+    }
+
+    // 닉네임을 userId로 변환
+    const userId = await getUuidByNickname(nickname);
+    if (!userId) {
+      return NextResponse.json({ error: '사용자를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const { currentPassword, newPassword } = body;
+
+    // 입력 데이터 검증
+    if (!currentPassword || typeof currentPassword !== 'string') {
+      return NextResponse.json({ error: '현재 비밀번호가 필요합니다.' }, { status: 400 });
+    }
+
+    if (!newPassword || typeof newPassword !== 'string') {
+      return NextResponse.json({ error: '새 비밀번호가 필요합니다.' }, { status: 400 });
+    }
+
+    if (newPassword.length < 6) {
+      return NextResponse.json({ error: '새 비밀번호는 최소 6자 이상이어야 합니다.' }, { status: 400 });
+    }
+
+    if (currentPassword === newPassword) {
+      return NextResponse.json({ error: '새 비밀번호는 현재 비밀번호와 달라야 합니다.' }, { status: 400 });
+    }
+
+    const useCase = createPasswordChangeUseCase();
+    const updatedUser = await useCase.execute(userId, currentPassword, newPassword);
+
+    if (!updatedUser) {
+      return NextResponse.json({ error: '비밀번호 변경에 실패했습니다.' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: '비밀번호가 성공적으로 변경되었습니다.'
+    }, { status: 200 });
+  } catch (error) {
+    console.error('[API] 비밀번호 변경 중 오류 발생:', error);
+    return NextResponse.json(
+      { error: '비밀번호 변경 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/api/users/[nickname]/profile-update/route.ts
+++ b/app/api/users/[nickname]/profile-update/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUuidByNickname } from '@/lib/getUserData';
+import {
+  ProfileUpdateUseCase,
+  ProfileImageUpdateUseCase,
+  PasswordChangeUseCase,
+  GetUserProfileUseCase,
+} from '@/backend/users/profile-update/applications/usecases/ProfileUpdateUseCase';
+import { SbProfileUpdateRepository } from '@/backend/users/profile-update/infrastructures/repositories/SbProfileUpdateRepository';
+import { entityToUserProfileResponseDto } from '@/backend/common/mappers/UserMapper';
+
+// 의존성 주입을 위한 UseCase 인스턴스 생성
+const createProfileUpdateUseCase = () => {
+  const repository = new SbProfileUpdateRepository();
+  return new ProfileUpdateUseCase(repository);
+};
+
+const createProfileImageUpdateUseCase = () => {
+  const repository = new SbProfileUpdateRepository();
+  return new ProfileImageUpdateUseCase(repository);
+};
+
+const createPasswordChangeUseCase = () => {
+  const repository = new SbProfileUpdateRepository();
+  return new PasswordChangeUseCase(repository);
+};
+
+const createGetUserProfileUseCase = () => {
+  const repository = new SbProfileUpdateRepository();
+  return new GetUserProfileUseCase(repository);
+};
+
+// 프로필 정보 조회 API
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ nickname: string }> }
+) {
+  try {
+    const { nickname } = await params;
+
+    if (!nickname || nickname.trim() === '') {
+      return NextResponse.json({ error: 'nickname이 필요합니다.' }, { status: 400 });
+    }
+
+    // 닉네임을 userId로 변환
+    const userId = await getUuidByNickname(nickname);
+    if (!userId) {
+      return NextResponse.json({ error: '사용자를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    const useCase = createGetUserProfileUseCase();
+    const user = await useCase.execute(userId);
+
+    if (!user) {
+      return NextResponse.json({ error: '사용자 정보를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    const userDto = entityToUserProfileResponseDto(user);
+    return NextResponse.json({ success: true, data: userDto }, { status: 200 });
+  } catch (error) {
+    console.error('[API] 사용자 프로필 조회 중 오류 발생:', error);
+    return NextResponse.json(
+      { error: '사용자 프로필 조회 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}
+
+// 프로필 정보 업데이트 API
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ nickname: string }> }
+) {
+  try {
+    const { nickname } = await params;
+
+    if (!nickname || nickname.trim() === '') {
+      return NextResponse.json({ error: 'nickname이 필요합니다.' }, { status: 400 });
+    }
+
+    // 닉네임을 userId로 변환
+    const userId = await getUuidByNickname(nickname);
+    if (!userId) {
+      return NextResponse.json({ error: '사용자를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const { name, address } = body;
+
+    // 업데이트할 데이터 검증
+    const updateData: Partial<{
+      name: string;
+      address: string;
+    }> = {};
+
+    if (name !== undefined) {
+      if (typeof name !== 'string' || name.trim() === '') {
+        return NextResponse.json({ error: '이름은 비어있을 수 없습니다.' }, { status: 400 });
+      }
+      updateData.name = name.trim();
+    }
+
+    if (address !== undefined) {
+      if (typeof address !== 'string' || address.trim() === '') {
+        return NextResponse.json({ error: '주소는 비어있을 수 없습니다.' }, { status: 400 });
+      }
+      updateData.address = address.trim();
+    }
+
+    // 업데이트할 데이터가 없는 경우
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: '업데이트할 데이터가 없습니다.' }, { status: 400 });
+    }
+
+    const useCase = createProfileUpdateUseCase();
+    const updatedUser = await useCase.execute(userId, updateData);
+
+    if (!updatedUser) {
+      return NextResponse.json({ error: '프로필 업데이트에 실패했습니다.' }, { status: 500 });
+    }
+
+    const userDto = entityToUserProfileResponseDto(updatedUser);
+    return NextResponse.json({
+      success: true,
+      message: '프로필이 성공적으로 업데이트되었습니다.',
+      data: userDto
+    }, { status: 200 });
+  } catch (error) {
+    console.error('[API] 프로필 업데이트 중 오류 발생:', error);
+    return NextResponse.json(
+      { error: '프로필 업데이트 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}
+
+// 프로필 이미지 업데이트 API
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ nickname: string }> }
+) {
+  try {
+    const { nickname } = await params;
+
+    if (!nickname || nickname.trim() === '') {
+      return NextResponse.json({ error: 'nickname이 필요합니다.' }, { status: 400 });
+    }
+
+    // 닉네임을 userId로 변환
+    const userId = await getUuidByNickname(nickname);
+    if (!userId) {
+      return NextResponse.json({ error: '사용자를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // FormData 파싱
+    const formData = await request.formData();
+    const imageFile = formData.get('image') as File;
+
+    if (!imageFile) {
+      return NextResponse.json({ error: '이미지 파일이 필요합니다.' }, { status: 400 });
+    }
+
+    const useCase = createProfileImageUpdateUseCase();
+    const result = await useCase.execute(userId, imageFile);
+
+    if (!result) {
+      return NextResponse.json({ error: '프로필 이미지 업데이트에 실패했습니다.' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: '프로필 이미지가 성공적으로 업데이트되었습니다.',
+      data: { profileImgUrl: result.profileImgUrl }
+    }, { status: 200 });
+  } catch (error) {
+    console.error('[API] 프로필 이미지 업데이트 중 오류 발생:', error);
+    return NextResponse.json(
+      { error: '프로필 이미지 업데이트 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,105 +1,217 @@
 /* Reset & Base */
 
-*, :after, :before {
-  background-repeat:no-repeat;
-  box-sizing:border-box;
+*,
+:after,
+:before {
+  background-repeat: no-repeat;
+  box-sizing: border-box;
 }
 
 :root {
-  -webkit-tap-highlight-color:transparent;
-  -webkit-text-size-adjust:100%;
-  text-size-adjust:100%;cursor:default;
-  line-height:1.5;
-  overflow-wrap:break-word;tab-size:4;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  cursor: default;
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  tab-size: 4;
 }
 
-html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, sub, sup, tt, var,  u, i,  dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video{
-  margin:0; 
-  padding:0; 
-  border:0; 
-  font-size:100%; 
-  font:inherit; 
-  vertical-align:baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+sub,
+sup,
+tt,
+var,
+u,
+i,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
 
-article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section{
-  display:block; 
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 
-ol, ul{
-  list-style:none; 
+ol,
+ul {
+  list-style: none;
 }
 
-blockquote:before, blockquote:after, q:before, q:after{
-  content:''; 
-  content:none; 
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 
-img, picture, video, canvas, svg {
-  max-width:100%;
+img,
+picture,
+video,
+canvas,
+svg {
+  max-width: 100%;
   height: auto;
-  vertical-align:top;
+  vertical-align: top;
 }
 
-a{
-  background-color:transparent;
-  text-decoration:none;
-  color:inherit;}
-a:active, a:hover{
-  outline:0;
+a {
+  background-color: transparent;
+  text-decoration: none;
+  color: inherit;
+}
+a:active,
+a:hover {
+  outline: 0;
 }
 
-[hidden], template{
-  display:none; 
+[hidden],
+template {
+  display: none;
 }
 
-button, input, optgroup, select, textarea{
-  color:inherit; 
-  font:inherit;  
-  margin:0;-webkit-border-radius:0;
-  border-radius:0;
-  border:0
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+  margin: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  border: 0;
 }
 button,
 html input[type="button"],
 input[type="reset"],
-input[type="submit"]{
+input[type="submit"] {
   /*-webkit-appearance:button;*/
-  cursor:pointer;
-  padding:0;
-  background:transparent;
+  cursor: pointer;
+  padding: 0;
+  background: transparent;
 }
 
 button[disabled],
-html input[disabled]{cursor:default; }
+html input[disabled] {
+  cursor: default;
+}
 input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration{
-  -webkit-appearance:none; 
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
 }
 
-input[type="search"]{
-  /*-webkit-appearance:textfield;*/box-sizing:content-box; 
+input[type="search"] {
+  /*-webkit-appearance:textfield;*/
+  box-sizing: content-box;
 }
 
 input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button{
-  height:auto; 
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
 }
 
-input[type="checkbox"], input[type="radio"]{
-  box-sizing:border-box; 
-  padding:0;
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
 }
 
-input{
-  line-height:normal;
+input {
+  line-height: normal;
 }
 
-textarea {-webkit-backface-visibility:hidden;
-  backface-visibility:hidden;
-  background-color:transparent;
-  border:0;word-break:keep-all;
-  word-wrap:break-word
+textarea {
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  background-color: transparent;
+  border: 0;
+  word-break: keep-all;
+  word-wrap: break-word;
 }
 
 html,
@@ -125,15 +237,15 @@ body {
   align-items: center;
   max-width: 768px;
   width: 100%;
+  height: 100%;
   border: 1px solid #d9d9d9;
   background-color: #fff;
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE and Edge */
-
 }
 
-.main-container > div{padding:5rem 1.5rem 2rem !important;} /* 최하단 공통 레이아웃 */
-
-
+.main-container > div {
+  padding: 5rem 1.5rem 2rem !important;
+} /* 최하단 공통 레이아웃 */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next';
-import { gangwonEdu, pretendard } from '@/public/fonts/fonts';
-import './globals.css';
-import { QueryProvider } from '@/app/_components/QueryProvider';
-import { ImageProvider } from '@/lib/contexts/ImageContext';
-import LayoutWrapper from '@/app/_components/LayoutWrapper';
+import type { Metadata } from "next";
+import { gangwonEdu, pretendard } from "@/public/fonts/fonts";
+import "./globals.css";
+import { QueryProvider } from "@/app/_components/QueryProvider";
+import { ImageProvider } from "@/lib/contexts/ImageContext";
+import LayoutWrapper from "@/app/_components/LayoutWrapper";
 
 export const metadata: Metadata = {
-  title: 'POLAR',
-  description: '봉사활동이 즐거워지는 곳',
+  title: "POLAR",
+  description: "봉사활동이 즐거워지는 곳",
 };
 
 export default function RootLayout({
@@ -16,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang='en'>
+    <html lang="en">
       <body className={`${gangwonEdu.variable} ${pretendard.variable}`}>
         <QueryProvider>
           <ImageProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,22 @@
 // 온보딩 페이지 (루트 경로) - 첫 진입 페이지, 로그인/회원가입 버튼 및 앱 소개 슬라이드
 "use client";
-
-import { useRouter } from 'next/navigation';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Autoplay, Pagination } from 'swiper/modules';
-import 'swiper/css';
-import 'swiper/css/pagination';
-import styles from './Onboarding.module.css';
-import { useOnboardingAuth } from '@/lib/hooks/onboarding/useOnboardingAuth';
-import { useNavigation } from '@/lib/hooks/useNavigation';
-import { useOnboardingData } from '@/lib/hooks/onboarding/useOnboardingData';
+import Image from "next/image";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Autoplay, Pagination } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/pagination";
+import styles from "./Onboarding.module.css";
+import { useOnboardingAuth } from "@/lib/hooks/onboarding/useOnboardingAuth";
+import { useNavigation } from "@/lib/hooks/useNavigation";
+import { useOnboardingData } from "@/lib/hooks/onboarding/useOnboardingData";
 
 export default function Home() {
   // 온보딩 페이지 전용 인증 확인
   const { shouldRender } = useOnboardingAuth();
-  
+
   // 네비게이션 핸들러
   const { navigateToLogin, navigateToSignup } = useNavigation();
-  
+
   // 온보딩 데이터
   const { slides, swiperConfig } = useOnboardingData();
 
@@ -25,15 +24,6 @@ export default function Home() {
   if (!shouldRender) {
     return null;
   }
-
-  // 비인증 사용자만 온보딩 페이지 표시
-  // 로그인/회원가입 버튼 클릭 시 각 페이지로 이동
-  const handleLogin = () => {
-    router.push('/login');
-  };
-  const handleSignup = () => {
-    router.push('/sign-up');
-  };
 
   return (
     <div className={styles.onboardingWrap}>
@@ -52,7 +42,7 @@ export default function Home() {
             <SwiperSlide key={idx}>
               <div className={styles.slideContent}>
                 <h2 className={styles.slideTitle}>{slide.title}</h2>
-                
+
                 {/* 슬라이드별 인터랙션 요소 */}
                 <div className={styles.slideInteraction}>
                   {idx === 0 && (
@@ -62,7 +52,7 @@ export default function Home() {
                       <div className={styles.personJunior}>👨‍🎓</div>
                     </div>
                   )}
-                  
+
                   {idx === 1 && (
                     <div className={styles.interactionGrowth}>
                       <div className={styles.requestIcon}>📝</div>
@@ -70,16 +60,22 @@ export default function Home() {
                       <div className={styles.experienceIcon}>💡</div>
                     </div>
                   )}
-                  
+
                   {idx === 2 && (
                     <div className={styles.interactionReward}>
                       <div className={styles.helpIcon}>🤝</div>
                       <div className={styles.trophyIcon}>🏆</div>
                       <div className={styles.equalsIcon}>=</div>
-                      <img src="/images/logos/POLAR.png" alt="POLAR 로고" className={styles.polarLogo} />
+                      <Image
+                        src="/images/logos/POLAR.png"
+                        alt="POLAR 로고"
+                        width={120}
+                        height={40}
+                        className={styles.polarLogo}
+                      />
                     </div>
                   )}
-                  
+
                   {idx === 3 && (
                     <div className={styles.interactionSafety}>
                       <div className={styles.shieldIcon}>🛡️</div>
@@ -88,15 +84,19 @@ export default function Home() {
                     </div>
                   )}
                 </div>
-                
+
                 <p className={styles.slideDesc}>{slide.desc}</p>
               </div>
             </SwiperSlide>
           ))}
         </Swiper>
         <div className={styles.buttonWrap}>
-          <button className={styles.loginBtn} onClick={navigateToLogin}>로그인</button>
-          <button className={styles.signupBtn} onClick={navigateToSignup}>회원가입</button>
+          <button className={styles.loginBtn} onClick={navigateToLogin}>
+            로그인
+          </button>
+          <button className={styles.signupBtn} onClick={navigateToSignup}>
+            회원가입
+          </button>
         </div>
       </section>
     </div>

--- a/backend/users/profile-update/applications/dtos/profileUpdateDto.ts
+++ b/backend/users/profile-update/applications/dtos/profileUpdateDto.ts
@@ -1,0 +1,57 @@
+// ===== 요청 DTOs =====
+
+// 프로필 정보 업데이트 요청 DTO (닉네임, 나이 제외)
+export interface ProfileUpdateRequestDto {
+  name?: string;
+  address?: string;
+  profileImage?: File; // 프로필 이미지 파일
+}
+
+// 비밀번호 변경 요청 DTO
+export interface PasswordChangeRequestDto {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+// ===== 응답 DTOs =====
+
+// 프로필 업데이트 성공 응답 DTO
+export interface ProfileUpdateResponseDto {
+  success: boolean;
+  message: string;
+  updatedUser: {
+    name: string;
+    nickname: string;
+    profileImgUrl: string;
+    address: string;
+  };
+}
+
+// 비밀번호 변경 성공 응답 DTO
+export interface PasswordChangeResponseDto {
+  success: boolean;
+  message: string;
+}
+
+// ===== 에러 응답 DTOs =====
+
+// 프로필 업데이트 에러 응답 DTO
+export interface ProfileUpdateErrorDto {
+  success: false;
+  message: string;
+  errors?: {
+    field: string;
+    message: string;
+  }[];
+}
+
+// 비밀번호 변경 에러 응답 DTO
+export interface PasswordChangeErrorDto {
+  success: false;
+  message: string;
+  errors?: {
+    field: string;
+    message: string;
+  }[];
+}

--- a/backend/users/profile-update/applications/usecases/ProfileUpdateUseCase.ts
+++ b/backend/users/profile-update/applications/usecases/ProfileUpdateUseCase.ts
@@ -1,0 +1,210 @@
+import { CommonUserEntity } from '@/backend/users/user/domains/entities/CommonUserEntity';
+import { IProfileUpdateRepository } from '@/backend/users/profile-update/domains/repositories/IProfileUpdateRepository';
+
+/**
+ * 프로필 정보 업데이트 UseCase
+ */
+export class ProfileUpdateUseCase {
+  constructor(private readonly profileUpdateRepository: IProfileUpdateRepository) { }
+
+  /**
+   * 프로필 정보 업데이트
+   * @param userId - 사용자 ID
+   * @param profileData - 업데이트할 프로필 데이터
+   * @returns 업데이트된 사용자 정보
+   */
+  async execute(
+    userId: string,
+    profileData: Partial<{
+      name: string;
+      address: string;
+      profileImgUrl: string;
+    }>
+  ): Promise<CommonUserEntity | null> {
+    console.log(`[UseCase] 프로필 업데이트 시작 - 사용자 ID: ${userId}`, profileData);
+
+    try {
+      // 기존 사용자 정보 조회 (업데이트 전 검증용)
+      const existingUser = await this.profileUpdateRepository.getUserById(userId);
+      if (!existingUser) {
+        console.error(`[UseCase] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      // 프로필 정보 업데이트
+      const updatedUser = await this.profileUpdateRepository.updateProfile(userId, profileData);
+      if (!updatedUser) {
+        console.error(`[UseCase] 프로필 업데이트 실패 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[UseCase] 프로필 업데이트 성공 - ID: ${userId}`, updatedUser.toJSON());
+      return updatedUser;
+    } catch (error) {
+      console.error(`[UseCase] 프로필 업데이트 중 오류 발생 - ID: ${userId}`, error);
+      return null;
+    }
+  }
+}
+
+/**
+ * 프로필 이미지 업데이트 UseCase
+ */
+export class ProfileImageUpdateUseCase {
+  constructor(private readonly profileUpdateRepository: IProfileUpdateRepository) { }
+
+  /**
+   * 프로필 이미지 업데이트
+   * @param userId - 사용자 ID
+   * @param imageFile - 업로드할 이미지 파일
+   * @returns 업데이트된 프로필 이미지 URL
+   */
+  async execute(
+    userId: string,
+    imageFile: File
+  ): Promise<{ profileImgUrl: string } | null> {
+    console.log(`[UseCase] 프로필 이미지 업데이트 시작 - 사용자 ID: ${userId}`);
+
+    try {
+      // 기존 사용자 정보 조회 (업데이트 전 검증용)
+      const existingUser = await this.profileUpdateRepository.getUserById(userId);
+      if (!existingUser) {
+        console.error(`[UseCase] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      // 이미지 파일 유효성 검사
+      if (!imageFile || imageFile.size === 0) {
+        console.error(`[UseCase] 유효하지 않은 이미지 파일 - ID: ${userId}`);
+        return null;
+      }
+
+      // 지원하는 이미지 형식 검사
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+      if (!allowedTypes.includes(imageFile.type)) {
+        console.error(`[UseCase] 지원하지 않는 이미지 형식 - ID: ${userId}, type: ${imageFile.type}`);
+        return null;
+      }
+
+      // 파일 크기 검사 (5MB 제한)
+      const maxSize = 5 * 1024 * 1024; // 5MB
+      if (imageFile.size > maxSize) {
+        console.error(`[UseCase] 이미지 파일 크기 초과 - ID: ${userId}, size: ${imageFile.size}`);
+        return null;
+      }
+
+      // 프로필 이미지 업데이트
+      const result = await this.profileUpdateRepository.updateProfileImage(userId, imageFile);
+      if (!result) {
+        console.error(`[UseCase] 프로필 이미지 업데이트 실패 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[UseCase] 프로필 이미지 업데이트 성공 - ID: ${userId}`, result);
+      return result;
+    } catch (error) {
+      console.error(`[UseCase] 프로필 이미지 업데이트 중 오류 발생 - ID: ${userId}`, error);
+      return null;
+    }
+  }
+}
+
+/**
+ * 비밀번호 변경 UseCase
+ */
+export class PasswordChangeUseCase {
+  constructor(private readonly profileUpdateRepository: IProfileUpdateRepository) { }
+
+  /**
+   * 비밀번호 변경
+   * @param userId - 사용자 ID
+   * @param currentPassword - 현재 비밀번호
+   * @param newPassword - 새 비밀번호
+   * @returns 업데이트된 사용자 정보
+   */
+  async execute(
+    userId: string,
+    currentPassword: string,
+    newPassword: string
+  ): Promise<CommonUserEntity | null> {
+    console.log(`[UseCase] 비밀번호 변경 시작 - 사용자 ID: ${userId}`);
+
+    try {
+      // 기존 사용자 정보 조회
+      const existingUser = await this.profileUpdateRepository.getUserById(userId);
+      if (!existingUser) {
+        console.error(`[UseCase] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      // 현재 비밀번호 확인
+      const isCurrentPasswordValid = await this.profileUpdateRepository.verifyCurrentPassword(
+        userId,
+        currentPassword
+      );
+
+      if (!isCurrentPasswordValid) {
+        console.error(`[UseCase] 현재 비밀번호가 일치하지 않음 - ID: ${userId}`);
+        return null;
+      }
+
+      // 새 비밀번호 유효성 검사
+      if (!newPassword || newPassword.length < 6) {
+        console.error(`[UseCase] 새 비밀번호가 유효하지 않음 - ID: ${userId}`);
+        return null;
+      }
+
+      // 새 비밀번호가 현재 비밀번호와 다른지 확인
+      if (currentPassword === newPassword) {
+        console.error(`[UseCase] 새 비밀번호가 현재 비밀번호와 동일함 - ID: ${userId}`);
+        return null;
+      }
+
+      // 비밀번호 해시화 (실제 구현에서는 bcrypt 등 사용)
+      const hashedNewPassword = newPassword; // TODO: 실제 해시화 로직 적용
+
+      // 비밀번호 변경
+      const updatedUser = await this.profileUpdateRepository.updatePassword(userId, hashedNewPassword);
+      if (!updatedUser) {
+        console.error(`[UseCase] 비밀번호 변경 실패 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[UseCase] 비밀번호 변경 성공 - ID: ${userId}`);
+      return updatedUser;
+    } catch (error) {
+      console.error(`[UseCase] 비밀번호 변경 중 오류 발생 - ID: ${userId}`, error);
+      return null;
+    }
+  }
+}
+
+/**
+ * 사용자 정보 조회 UseCase
+ */
+export class GetUserProfileUseCase {
+  constructor(private readonly profileUpdateRepository: IProfileUpdateRepository) { }
+
+  /**
+   * 사용자 프로필 정보 조회
+   * @param userId - 사용자 ID
+   * @returns 사용자 정보
+   */
+  async execute(userId: string): Promise<CommonUserEntity | null> {
+    console.log(`[UseCase] 사용자 프로필 조회 시작 - 사용자 ID: ${userId}`);
+
+    try {
+      const user = await this.profileUpdateRepository.getUserById(userId);
+      if (!user) {
+        console.error(`[UseCase] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[UseCase] 사용자 프로필 조회 성공 - ID: ${userId}`, user.toJSON());
+      return user;
+    } catch (error) {
+      console.error(`[UseCase] 사용자 프로필 조회 중 오류 발생 - ID: ${userId}`, error);
+      return null;
+    }
+  }
+} 

--- a/backend/users/profile-update/domains/repositories/IProfileUpdateRepository.ts
+++ b/backend/users/profile-update/domains/repositories/IProfileUpdateRepository.ts
@@ -1,0 +1,35 @@
+import { CommonUserEntity } from '@/backend/users/user/domains/entities/CommonUserEntity';
+
+// 프로필 업데이트 리포지토리 인터페이스
+export interface IProfileUpdateRepository {
+  // 프로필 정보 업데이트
+  updateProfile(
+    userId: string,
+    profileData: Partial<{
+      name: string;
+      address: string;
+      profileImgUrl: string;
+    }>
+  ): Promise<CommonUserEntity | null>;
+
+  // 프로필 이미지 업로드 및 URL 업데이트
+  updateProfileImage(
+    userId: string,
+    imageFile: File
+  ): Promise<{ profileImgUrl: string } | null>;
+
+  // 비밀번호 변경
+  updatePassword(
+    userId: string,
+    hashedNewPassword: string
+  ): Promise<CommonUserEntity | null>;
+
+  // 현재 비밀번호 확인
+  verifyCurrentPassword(
+    userId: string,
+    currentPassword: string
+  ): Promise<boolean>;
+
+  // 사용자 정보 조회 (업데이트 전 검증용)
+  getUserById(userId: string): Promise<CommonUserEntity | null>;
+} 

--- a/backend/users/profile-update/infrastructures/repositories/SbProfileUpdateRepository.ts
+++ b/backend/users/profile-update/infrastructures/repositories/SbProfileUpdateRepository.ts
@@ -1,0 +1,223 @@
+import { supabase } from '@/backend/common/utils/supabaseClient';
+import { CommonUserEntity } from '@/backend/users/user/domains/entities/CommonUserEntity';
+import { IProfileUpdateRepository } from '@/backend/users/profile-update/domains/repositories/IProfileUpdateRepository';
+import { fromDbObject } from '@/backend/common/mappers/UserMapper';
+
+export class SbProfileUpdateRepository implements IProfileUpdateRepository {
+  async updateProfile(
+    userId: string,
+    profileData: Partial<{
+      name: string;
+      address: string;
+      profileImgUrl: string;
+    }>
+  ): Promise<CommonUserEntity | null> {
+    console.log(`[Repository] 프로필 업데이트 시작 - ID: ${userId}`, profileData);
+
+    try {
+      // 업데이트할 데이터 준비 (snake_case로 변환)
+      const updateData: {
+        name?: string;
+        address?: string;
+        profile_img_url?: string;
+      } = {};
+
+      if (profileData.name !== undefined) updateData.name = profileData.name;
+      if (profileData.address !== undefined) updateData.address = profileData.address;
+      if (profileData.profileImgUrl !== undefined) updateData.profile_img_url = profileData.profileImgUrl;
+
+      console.log(`[Repository] 프로필 업데이트 데이터 준비 완료:`, updateData);
+
+      const { data, error } = await supabase
+        .from('users')
+        .update(updateData)
+        .eq('id', userId)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('[Repository] Supabase 프로필 업데이트 오류:', error);
+        return null;
+      }
+
+      if (!data) {
+        console.log(`[Repository] 업데이트된 사용자 데이터가 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[Repository] 프로필 업데이트 성공 - ID: ${userId}`, data);
+
+      // 업데이트된 데이터를 Entity로 변환하여 반환
+      const updatedEntity = fromDbObject(data);
+
+      console.log(
+        `[Repository] 업데이트된 Entity 변환 완료 - ID: ${userId}`,
+        updatedEntity.toJSON()
+      );
+      return updatedEntity;
+    } catch (error) {
+      console.error('[Repository] 프로필 업데이트 중 예외 발생:', error);
+      return null;
+    }
+  }
+
+  async updateProfileImage(
+    userId: string,
+    imageFile: File
+  ): Promise<{ profileImgUrl: string } | null> {
+    console.log(`[Repository] 프로필 이미지 업데이트 시작 - ID: ${userId}`);
+
+    try {
+      // 파일 업로드
+      const fileExt = imageFile.name.split('.').pop();
+      const fileName = `${userId}_${Date.now()}.${fileExt}`;
+      const filePath = `profile-images/${fileName}`;
+
+      const { data: uploadData, error: uploadError } = await supabase.storage
+        .from('images')
+        .upload(filePath, imageFile);
+
+      if (uploadError) {
+        console.error('[Repository] 이미지 업로드 오류:', uploadError);
+        return null;
+      }
+
+      // 업로드된 이미지의 공개 URL 생성
+      const { data: urlData } = supabase.storage
+        .from('images')
+        .getPublicUrl(filePath);
+
+      const profileImgUrl = urlData.publicUrl;
+
+      // 사용자 프로필 이미지 URL 업데이트
+      const { data, error } = await supabase
+        .from('users')
+        .update({ profile_img_url: profileImgUrl })
+        .eq('id', userId)
+        .select('profile_img_url')
+        .single();
+
+      if (error) {
+        console.error('[Repository] 프로필 이미지 URL 업데이트 오류:', error);
+        return null;
+      }
+
+      console.log(`[Repository] 프로필 이미지 업데이트 성공 - ID: ${userId}`, { profileImgUrl });
+
+      return { profileImgUrl };
+    } catch (error) {
+      console.error('[Repository] 프로필 이미지 업데이트 중 예외 발생:', error);
+      return null;
+    }
+  }
+
+  async updatePassword(
+    userId: string,
+    hashedNewPassword: string
+  ): Promise<CommonUserEntity | null> {
+    console.log(`[Repository] 비밀번호 변경 시작 - ID: ${userId}`);
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .update({ password: hashedNewPassword })
+        .eq('id', userId)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('[Repository] Supabase 비밀번호 변경 오류:', error);
+        return null;
+      }
+
+      if (!data) {
+        console.log(`[Repository] 비밀번호 변경된 사용자 데이터가 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[Repository] 비밀번호 변경 성공 - ID: ${userId}`);
+
+      // 업데이트된 데이터를 Entity로 변환하여 반환
+      const updatedEntity = fromDbObject(data);
+
+      console.log(
+        `[Repository] 비밀번호 변경 Entity 변환 완료 - ID: ${userId}`,
+        updatedEntity.toJSON()
+      );
+      return updatedEntity;
+    } catch (error) {
+      console.error('[Repository] 비밀번호 변경 중 예외 발생:', error);
+      return null;
+    }
+  }
+
+  async verifyCurrentPassword(
+    userId: string,
+    currentPassword: string
+  ): Promise<boolean> {
+    console.log(`[Repository] 현재 비밀번호 확인 시작 - ID: ${userId}`);
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('password')
+        .eq('id', userId)
+        .single();
+
+      if (error) {
+        console.error('[Repository] Supabase 비밀번호 조회 오류:', error);
+        return false;
+      }
+
+      if (!data) {
+        console.log(`[Repository] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return false;
+      }
+
+      // 비밀번호 비교 (실제 구현에서는 해시 비교)
+      const isMatch = data.password === currentPassword;
+
+      console.log(`[Repository] 비밀번호 확인 결과 - ID: ${userId}, 일치: ${isMatch}`);
+      return isMatch;
+    } catch (error) {
+      console.error('[Repository] 비밀번호 확인 중 예외 발생:', error);
+      return false;
+    }
+  }
+
+  async getUserById(userId: string): Promise<CommonUserEntity | null> {
+    console.log(`[Repository] 사용자 조회 시작 - ID: ${userId}`);
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', userId)
+        .single();
+
+      if (error) {
+        console.error('[Repository] Supabase 사용자 조회 오류:', error);
+        return null;
+      }
+
+      if (!data) {
+        console.log(`[Repository] 사용자를 찾을 수 없음 - ID: ${userId}`);
+        return null;
+      }
+
+      console.log(`[Repository] 사용자 데이터 조회 성공 - ID: ${userId}`, data);
+
+      // 데이터를 Entity로 변환
+      const userEntity = fromDbObject(data);
+
+      console.log(
+        `[Repository] Entity 변환 완료 - ID: ${userId}`,
+        userEntity.toJSON()
+      );
+      return userEntity;
+    } catch (error) {
+      console.error('[Repository] 사용자 조회 중 예외 발생:', error);
+      return null;
+    }
+  }
+} 

--- a/backend/users/user/applications/usecases/CommonUserUseCase.ts
+++ b/backend/users/user/applications/usecases/CommonUserUseCase.ts
@@ -94,6 +94,13 @@ export class UserValidator {
   static validateProfileImageUrl(url: string): void {
     console.log(`[Validator] 프로필 이미지 URL 검증 시작: ${url}`);
 
+    // 빈 URL은 허용 (프로필 이미지가 없는 경우)
+    if (!url || url.trim() === '') {
+      console.log(`[Validator] 프로필 이미지 URL 검증 성공: 빈 URL 허용`);
+      return;
+    }
+
+    // Supabase Storage URL 형식 확인
     if (url && !url.startsWith('http') && !url.startsWith('https')) {
       console.error(
         `[Validator] 프로필 이미지 URL 검증 실패: 프로토콜 오류 - ${url}`
@@ -229,7 +236,6 @@ export class CommonUserUseCase {
       // 프로필 이미지 URL을 빈 문자열로 설정
       const updatedUser = new CommonUserEntity(
         existingUser.id,
-        existingUser.uuid,
         existingUser.phoneNumber,
         existingUser.password,
         existingUser.email,
@@ -324,7 +330,6 @@ export class CommonUserUseCase {
       // 업데이트된 사용자 Entity 생성
       const updatedUser = new CommonUserEntity(
         existingUser.id,
-        existingUser.uuid,
         updates.phoneNumber ?? existingUser.phoneNumber,
         updates.password ?? existingUser.password,
         updates.email ?? existingUser.email,

--- a/lib/api_front/profileUpdate.api.ts
+++ b/lib/api_front/profileUpdate.api.ts
@@ -1,4 +1,4 @@
-import { API_ENDPOINTS, QUERY_KEYS } from '../constants/api';
+import { API_ENDPOINTS } from '../constants/api';
 import apiClient from '../http.api';
 import { UserProfileResponseDto } from '@/backend/common/dtos/UserDto';
 import { ApiResponse } from '../http.api';
@@ -17,7 +17,7 @@ export interface PasswordChangeRequest {
 
 // 프로필 이미지 업데이트 응답 타입
 export interface ProfileImageUpdateResponse {
-  profileImgUrl: string;
+  url: string;
 }
 
 // 프로필 정보 조회
@@ -40,7 +40,7 @@ export const updateUserProfile = async (
   return response.data.data!;
 };
 
-// 프로필 이미지 업데이트
+// 프로필 이미지 업데이트 (기존 이미지 업로드 API 사용)
 export const updateUserProfileImage = async (
   nickname: string,
   imageFile: File
@@ -48,8 +48,8 @@ export const updateUserProfileImage = async (
   const formData = new FormData();
   formData.append('image', imageFile);
 
-  const response = await apiClient.patch<ApiResponse<ProfileImageUpdateResponse>>(
-    API_ENDPOINTS.USER_PROFILE_UPDATE(nickname),
+  const response = await apiClient.post<ProfileImageUpdateResponse>(
+    API_ENDPOINTS.PROFILE_IMAGE,
     formData,
     {
       headers: {
@@ -57,7 +57,7 @@ export const updateUserProfileImage = async (
       },
     }
   );
-  return response.data.data!;
+  return response.data;
 };
 
 // 비밀번호 변경

--- a/lib/api_front/profileUpdate.api.ts
+++ b/lib/api_front/profileUpdate.api.ts
@@ -1,0 +1,72 @@
+import { API_ENDPOINTS, QUERY_KEYS } from '../constants/api';
+import apiClient from '../http.api';
+import { UserProfileResponseDto } from '@/backend/common/dtos/UserDto';
+import { ApiResponse } from '../http.api';
+
+// 프로필 업데이트 요청 타입
+export interface ProfileUpdateRequest {
+  name?: string;
+  address?: string;
+}
+
+// 비밀번호 변경 요청 타입
+export interface PasswordChangeRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
+// 프로필 이미지 업데이트 응답 타입
+export interface ProfileImageUpdateResponse {
+  profileImgUrl: string;
+}
+
+// 프로필 정보 조회
+export const getUserProfileForUpdate = async (nickname: string): Promise<UserProfileResponseDto> => {
+  const response = await apiClient.get<ApiResponse<UserProfileResponseDto>>(
+    API_ENDPOINTS.USER_PROFILE_UPDATE(nickname)
+  );
+  return response.data.data!;
+};
+
+// 프로필 정보 업데이트
+export const updateUserProfile = async (
+  nickname: string,
+  profileData: ProfileUpdateRequest
+): Promise<UserProfileResponseDto> => {
+  const response = await apiClient.put<ApiResponse<UserProfileResponseDto>>(
+    API_ENDPOINTS.USER_PROFILE_UPDATE(nickname),
+    profileData
+  );
+  return response.data.data!;
+};
+
+// 프로필 이미지 업데이트
+export const updateUserProfileImage = async (
+  nickname: string,
+  imageFile: File
+): Promise<ProfileImageUpdateResponse> => {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  const response = await apiClient.patch<ApiResponse<ProfileImageUpdateResponse>>(
+    API_ENDPOINTS.USER_PROFILE_UPDATE(nickname),
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  return response.data.data!;
+};
+
+// 비밀번호 변경
+export const changeUserPassword = async (
+  nickname: string,
+  passwordData: PasswordChangeRequest
+): Promise<void> => {
+  await apiClient.put<ApiResponse>(
+    API_ENDPOINTS.USER_PASSWORD_CHANGE(nickname),
+    passwordData
+  );
+}; 

--- a/lib/api_front/withdrawal.api.ts
+++ b/lib/api_front/withdrawal.api.ts
@@ -1,0 +1,25 @@
+import { API_ENDPOINTS } from '../constants/api';
+import apiClient from '../http.api';
+
+// 회원 탈퇴 요청 인터페이스
+export interface WithdrawalRequest {
+  userId: number;
+  confirmPassword: string;
+  reason?: string;
+}
+
+// 회원 탈퇴 응답 인터페이스
+export interface WithdrawalResponse {
+  success: boolean;
+  message: string;
+  userId?: number;
+}
+
+// 회원 탈퇴 API 호출
+export const withdrawUser = async (data: WithdrawalRequest): Promise<WithdrawalResponse> => {
+  const response = await apiClient.post<WithdrawalResponse>(
+    API_ENDPOINTS.WITHDRAWAL,
+    data
+  );
+  return response.data;
+}; 

--- a/lib/constants/api.ts
+++ b/lib/constants/api.ts
@@ -3,6 +3,8 @@ export const API_ENDPOINTS = {
   // 사용자 관련
   USERS: '/api/users',
   USER_PROFILE: (nickname: string) => `/api/users/${nickname}`,
+  USER_PROFILE_UPDATE: (nickname: string) => `/api/users/${nickname}/profile-update`,
+  USER_PASSWORD_CHANGE: (nickname: string) => `/api/users/${nickname}/password-change`,
   USER_SEARCH: '/api/users/search',
 
   // 인증 관련
@@ -58,6 +60,8 @@ export const QUERY_KEYS = {
   // 사용자 관련
   USERS: ['users'] as const,
   USER_PROFILE: (nickname: string) => ['users', 'profile', nickname] as const,
+  USER_PROFILE_UPDATE: (nickname: string) => ['users', 'profile-update', nickname] as const,
+  USER_PASSWORD_CHANGE: (nickname: string) => ['users', 'password-change', nickname] as const,
   USER_SEARCH: (query: string) => ['users', 'search', query] as const,
 
   // 도움 요청 관련

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -25,3 +25,6 @@ export { useSendMessage } from './chats/useSendMessage';
 export { useRealtimeChat } from './chats/useRealtimeChat';
 export { useChatInput } from './chats/useChatInput';
 export { useChatRoomDetailWithHelps } from './chats/useChatRoomDetailWithHelps';
+
+// 회원 탈퇴 관련 훅들
+export { useWithdrawal } from './useWithdrawal';

--- a/lib/hooks/profileUpdate.ts
+++ b/lib/hooks/profileUpdate.ts
@@ -76,7 +76,7 @@ export const useUpdateUserProfileImage = () => {
           if (oldData) {
             return {
               ...oldData,
-              profileImgUrl: data.profileImgUrl,
+              profileImgUrl: data.url,
             };
           }
           return oldData;
@@ -89,7 +89,7 @@ export const useUpdateUserProfileImage = () => {
           if (oldData) {
             return {
               ...oldData,
-              profileImgUrl: data.profileImgUrl,
+              profileImgUrl: data.url,
             };
           }
           return oldData;

--- a/lib/hooks/profileUpdate.ts
+++ b/lib/hooks/profileUpdate.ts
@@ -1,0 +1,118 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getUserProfileForUpdate,
+  updateUserProfile,
+  updateUserProfileImage,
+  changeUserPassword,
+  ProfileUpdateRequest,
+  PasswordChangeRequest,
+} from '../api_front/profileUpdate.api';
+import { QUERY_KEYS } from '../constants/api';
+import { UserProfileResponseDto } from '@/backend/common/dtos/UserDto';
+
+// 프로필 정보 조회 훅
+export const useUserProfileForUpdate = (nickname: string) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.USER_PROFILE_UPDATE(nickname),
+    queryFn: () => getUserProfileForUpdate(nickname),
+    enabled: !!nickname,
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+};
+
+// 프로필 정보 업데이트 훅
+export const useUpdateUserProfile = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ nickname, profileData }: { nickname: string; profileData: ProfileUpdateRequest }) =>
+      updateUserProfile(nickname, profileData),
+    onSuccess: (data, { nickname }) => {
+      // 프로필 업데이트 관련 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.USER_PROFILE_UPDATE(nickname),
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.USER_PROFILE(nickname),
+      });
+
+      // 캐시 업데이트
+      queryClient.setQueryData(
+        QUERY_KEYS.USER_PROFILE_UPDATE(nickname),
+        data
+      );
+      queryClient.setQueryData(
+        QUERY_KEYS.USER_PROFILE(nickname),
+        data
+      );
+    },
+    onError: (error) => {
+      console.error('프로필 업데이트 실패:', error);
+    },
+  });
+};
+
+// 프로필 이미지 업데이트 훅
+export const useUpdateUserProfileImage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ nickname, imageFile }: { nickname: string; imageFile: File }) =>
+      updateUserProfileImage(nickname, imageFile),
+    onSuccess: (data, { nickname }) => {
+      // 프로필 업데이트 관련 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.USER_PROFILE_UPDATE(nickname),
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.USER_PROFILE(nickname),
+      });
+
+      // 기존 프로필 데이터에 이미지 URL 업데이트
+      queryClient.setQueryData<UserProfileResponseDto>(
+        QUERY_KEYS.USER_PROFILE_UPDATE(nickname),
+        (oldData) => {
+          if (oldData) {
+            return {
+              ...oldData,
+              profileImgUrl: data.profileImgUrl,
+            };
+          }
+          return oldData;
+        }
+      );
+
+      queryClient.setQueryData<UserProfileResponseDto>(
+        QUERY_KEYS.USER_PROFILE(nickname),
+        (oldData) => {
+          if (oldData) {
+            return {
+              ...oldData,
+              profileImgUrl: data.profileImgUrl,
+            };
+          }
+          return oldData;
+        }
+      );
+    },
+    onError: (error) => {
+      console.error('프로필 이미지 업데이트 실패:', error);
+    },
+  });
+};
+
+// 비밀번호 변경 훅
+export const useChangeUserPassword = () => {
+  return useMutation({
+    mutationFn: ({ nickname, passwordData }: { nickname: string; passwordData: PasswordChangeRequest }) =>
+      changeUserPassword(nickname, passwordData),
+    onSuccess: () => {
+      // 비밀번호 변경은 다른 데이터에 영향을 주지 않으므로 캐시 무효화 없음
+      console.log('비밀번호 변경 성공');
+    },
+    onError: (error) => {
+      console.error('비밀번호 변경 실패:', error);
+    },
+  });
+}; 

--- a/lib/hooks/useWithdrawal.ts
+++ b/lib/hooks/useWithdrawal.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { withdrawUser, WithdrawalRequest } from '../api_front/withdrawal.api';
+import { useAuth } from './useAuth';
+import { useRouter } from 'next/navigation';
+
+/**
+ * 회원 탈퇴를 위한 tanstack query mutation 훅
+ * 
+ * @example
+ * ```tsx
+ * const { mutate: withdraw, isPending, error } = useWithdrawal();
+ * 
+ * const handleWithdrawal = () => {
+ *   withdraw({
+ *     userId: 123,
+ *     confirmPassword: 'password123',
+ *     reason: '서비스 불만족'
+ *   });
+ * };
+ * ```
+ */
+export const useWithdrawal = () => {
+  const queryClient = useQueryClient();
+  const { logout } = useAuth();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (data: WithdrawalRequest) => withdrawUser(data),
+    onSuccess: (data) => {
+      console.log('[useWithdrawal] 회원 탈퇴 성공:', data);
+      
+      // 캐시 무효화
+      queryClient.clear();
+      
+      // 로그아웃 처리
+      logout();
+      
+      // 홈페이지로 리다이렉트
+      router.push('/');
+    },
+    onError: (error) => {
+      console.error('[useWithdrawal] 회원 탈퇴 실패:', error);
+    },
+  });
+}; 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: #130 

---

## 🛠 작업 내용

- [ ] 회원 정보 수정 페이지 퍼블리싱
- [ ] 회원 정보 수정 기능 구현
  - [ ] 닉네임, 나이, 전화번호, 이메일 외 정보 수정 가능 확인
- [ ] 로그아웃 기능 구현 (쿠키 삭제)

---

## 🚀 기타 사항

> 회원 탈퇴 로직 관련해서는 DB 제약조건과의 충돌로 인해 소프트한 삭제가 불가능한 상황입니다.
> 우선 발표에서는 중요한 부분은 아니기에 보류하기로 잠정 합의 완료.

<img width="960" height="968" alt="image" src="https://github.com/user-attachments/assets/075c98a2-4c6b-4457-a9fe-a8e25b15409d" />

<img width="960" height="968" alt="image" src="https://github.com/user-attachments/assets/de1b4281-9bd2-4a5f-98fa-3062794063ec" />

close #130